### PR TITLE
コメントの取得と各ブックマークへの割り当て

### DIFF
--- a/frontend/pages/projects/_project.vue
+++ b/frontend/pages/projects/_project.vue
@@ -107,24 +107,28 @@ export default {
     },
 
     async getComments() {
-      // プロジェクトと一致するコメントをfirestoreから取得
-      const db = this.$fire.firestore
-      const snapshot = await db
-        .collection('comments')
-        .where('project', '==', this.projectName)
-        .get()
-      const comments = snapshot.docs.map((doc) => {
-        return doc.data()
-      })
+      try {
+        // プロジェクトと一致するコメントをfirestoreから取得
+        const db = this.$fire.firestore
+        const snapshot = await db
+          .collection('comments')
+          .where('project', '==', this.projectName)
+          .get()
+        const comments = snapshot.docs.map((doc) => {
+          return doc.data()
+        })
 
-      // 一致するbookmarkにcommentsを振り分ける
-      this.bookmarks.forEach((bookmark) => {
-        const filteredComments = comments.filter(
-          (comment) => comment.bookmark_url === bookmark.url
-        )
-        bookmark.comments = filteredComments
-      })
-      console.log(this.bookmarks)
+        // 一致するbookmarkにcommentsを振り分ける
+        this.bookmarks.forEach((bookmark) => {
+          const filteredComments = comments.filter(
+            (comment) => comment.bookmark_url === bookmark.url
+          )
+          bookmark.comments = filteredComments
+        })
+        console.log(this.bookmarks)
+      } catch (error) {
+        console.log(error)
+      }
     },
 
     getCategories() {

--- a/frontend/pages/projects/_project.vue
+++ b/frontend/pages/projects/_project.vue
@@ -49,6 +49,7 @@ export default {
     this.projectName = this.$route.params.project
     console.log(this.projectName)
     this.getBookmarks()
+    this.getComments()
   },
   methods: {
     async getBookmarks() {
@@ -103,6 +104,27 @@ export default {
         console.log(error)
       }
       this.submitLoading = false
+    },
+
+    async getComments() {
+      // プロジェクトと一致するコメントをfirestoreから取得
+      const db = this.$fire.firestore
+      const snapshot = await db
+        .collection('comments')
+        .where('project', '==', this.projectName)
+        .get()
+      const comments = snapshot.docs.map((doc) => {
+        return doc.data()
+      })
+
+      // 一致するbookmarkにcommentsを振り分ける
+      this.bookmarks.forEach((bookmark) => {
+        const filteredComments = comments.filter(
+          (comment) => comment.bookmark_url === bookmark.url
+        )
+        bookmark.comments = filteredComments
+      })
+      console.log(this.bookmarks)
     },
 
     getCategories() {


### PR DESCRIPTION
#35 

- 開いているプロジェクト名と一致するコメントを`Firestore`から取得
- コメントをURLの一致する各ブックマークに割り当てる